### PR TITLE
Use parser from `graphql-ruby`

### DIFF
--- a/lib/graphql/remote_loader/query_merger.rb
+++ b/lib/graphql/remote_loader/query_merger.rb
@@ -1,299 +1,82 @@
 module GraphQL
   module RemoteLoader
-
     # Given a list of queries and their prime UIDs, generate the merged and labeled
     # GraphQL query to be sent off to the remote backend.
     class QueryMerger
       class << self
         def merge(queries_and_primes)
-          new_ast = []
+          parsed_queries = queries_and_primes.map do |query, prime|
+            parsed_query = parse(query)
+            attach_primes!(parsed_query.definitions[0].children, prime)
 
-          queries_and_primes.each do |query, prime|
-            parsed_query = [parse(query)]
-            attach_primes!(parsed_query, prime)
-            merge_query(parsed_query, new_ast)
+            parsed_query
           end
 
-          query_string_from_ast(new_ast)
+          merge_parsed_queries(parsed_queries).to_query_string
         end
 
         private
 
-        def merge_query(query, ast)
-          query.each do |query_field|
-            matching_field = ast.find do |ast_field|
-              query_field[:field] == ast_field[:field] &&
-                query_field[:arguments] == ast_field[:arguments]
+        def merge_parsed_queries(parsed_queries)
+          merged_query = parsed_queries.pop
+
+          parsed_queries.each do |query|
+            merge_query_recursive(query.definitions[0], merged_query.definitions[0])
+          end
+
+          apply_aliases!(merged_query.definitions[0].selections)
+          merged_query
+        end
+
+        # merges a_query into b_query
+        def merge_query_recursive(a_query, b_query)
+          a_query.selections.each do |a_query_selection|
+            matching_field = b_query.selections.find do |b_query_selection|
+              a_query_selection.name == b_query_selection.name &&
+                arguments_equal?(a_query_selection.arguments, b_query_selection.arguments)
             end
 
             if matching_field
-              matching_field[:primes] *= query_field[:primes]
-              merge_query(query_field[:body], matching_field[:body])
+              new_prime = matching_field.instance_variable_get(:@prime) *
+                a_query_selection.instance_variable_get(:@prime)
+
+              matching_field.instance_variable_set(:@prime, new_prime)
+              merge_query_recursive(a_query_selection, matching_field)
             else
-              ast << query_field
+              b_query.selections << a_query_selection
             end
           end
         end
 
-        def attach_primes!(query, prime)
-          query.each do |field|
-            field[:primes] = prime
-            attach_primes!(field[:body], prime)
+        # Are two lists of arguments equal?
+        def arguments_equal?(a_args, b_args)
+          a_args.map { |arg| {name: arg.name, value: arg.value}.to_s }.sort ==
+            b_args.map { |arg| {name: arg.name, value: arg.value}.to_s }.sort
+        end
+
+        def attach_primes!(query_fields, prime)
+          query_fields.each do |field|
+            field.instance_variable_set(:@prime, prime)
+            attach_primes!(field.children, prime)
           end
         end
 
-        def query_string_from_ast(ast)
-          ast_node_strings = ast.map do |ast_node|
-            query_string_for_node(ast_node)
-          end.join(" ")
-          ast_node_strings
-        end
-
-        def query_string_for_node(node)
-          field = node[:field]
-
-          # TODO: This won't work for fields named `query`. Fix once
-          # I move to Roberts non-jank parser
-          unless field.include?("...") || field == "query"
-            # assign preix if not a spread
-            field = "p#{node[:primes]}#{field}: #{field}"
-          end
-
-          args = node[:arguments].map do |arg, value|
-            value = "\"#{value}\"" if value.is_a? String
-
-            "#{arg}: #{value}"
-          end
-
-          arg_string = unless args.empty?
-            "(#{args.join(",")})"
-          else
-            ""
-          end
-
-          body_string = unless node[:body].empty?
-            str = node[:body].map do |node|
-              query_string_for_node(node)
+        def apply_aliases!(query_selections)
+          query_selections.each do |selection|
+            unless selection.is_a?(GraphQL::Language::Nodes::InlineFragment)
+              prime_factor = selection.instance_variable_get(:@prime)
+              selection.alias = "p#{prime_factor}#{selection.name}"
             end
 
-            "{ #{str.join(" ")} }"
+            apply_aliases!(selection.selections)
           end
-
-          "#{field}#{arg_string} #{body_string}".strip
         end
 
+        # Allows "foo" or "query { foo }"
         def parse(query)
-          tokenizer = QueryTokenizer.new("query { #{query} }")
-          QueryAST.build(tokenizer)
-        end
-
-        class QueryAST
-          class ParseException < Exception; end
-
-          class << self
-            def build(tokenizer)
-              result = build_node(tokenizer)
-            end
-
-            def build_node(tokenizer)
-              {
-                field: get_field(tokenizer),
-                arguments: get_args(tokenizer),
-                body: build_body(tokenizer)
-              }
-            end
-
-            def get_field(tokenizer)
-              token = tokenizer.pop
-
-              if token[:type] == :spread
-                validate_token_type(tokenizer.pop, :on)
-                spread_type = tokenizer.pop[:string]
-
-                return "... on #{spread_type}"
-              end
-
-              validate_token_type(token, :field)
-
-              throw_parse_exception(token, "field") unless (token[:type] == :field)
-
-              token[:string]
-            end
-
-            def get_args(tokenizer)
-              args = {}
-              return args unless (tokenizer.peek[:type] == :left_paren)
-
-              # remove "("
-              tokenizer.pop
-
-              while true
-                token = tokenizer.pop
-                validate_token_type(token, :key)
-
-                # Remove :
-                key = token[:string].sub(":", "")
-
-                token = tokenizer.pop
-                value = case token[:type]
-                        when :string
-                          token[:string][1..-2] # remove ""
-                        when :int
-                          Integer(token[:string])
-                        when :float
-                          Float(token[:string])
-                        when :true
-                          true
-                        when :false
-                          false
-                        else
-                          raise ParseException, "Expected string, int, float, or boolean, got #{token[:string]}"
-                        end
-
-                args[key.to_sym] = value
-
-                if tokenizer.peek[:type] == :comma
-                  tokenizer.pop
-                elsif tokenizer.peek[:type] == :right_paren
-                  tokenizer.pop
-                  break
-                else
-                  raise ParseException, "Expected comma or right paren, got #{tokenizer[:string]}"
-                end
-              end
-
-              args
-            end
-
-            def build_body(tokenizer)
-              body = []
-              return body unless (tokenizer.peek[:type] == :left_brace)
-
-              # remove "{"
-              tokenizer.pop
-
-              while true
-                body << build_node(tokenizer)
-                break if (tokenizer.peek[:type] == :right_brace)
-              end
-
-              # remove "}"
-              tokenizer.pop
-
-              body
-            end
-
-            def validate_token_type(token, expected_type)
-              unless token[:type] == expected_type
-                raise ParseException, "Expected #{expected_type.to_s} token, got #{token[:string]}"
-              end
-            end
-          end
-        end
-
-        class QueryTokenizer
-          def initialize(query)
-            @query = query.chars
-            set_next_token
-          end
-
-          # Get next token, without removing from stream
-          def peek
-            @next_token
-          end
-
-          # Pop next token
-          def pop
-            token = @next_token
-            set_next_token if token
-
-            token
-          end
-
-          private
-
-          # Read @query to set @next_token
-          def set_next_token
-            next_token_string = extract_token_string_from_query
-            @next_token = tokenize_string(next_token_string)
-          end
-
-          def extract_token_string_from_query
-            trim_leading_whitespace
-
-            token_string = ""
-            while true
-              next_char = @query.first || break
-
-              if is_brace_or_bracket_or_comma?(next_char)
-                if token_string.length == 0
-                  token_string << @query.shift
-                end
-
-                break
-              else
-                if !is_whitespace?(@query.first)
-                  token_string << @query.shift
-                else
-                  break
-                end
-              end
-            end
-
-            token_string
-          end
-
-          def tokenize_string(next_token_string)
-            token = case next_token_string
-            when '{'
-              :left_brace
-            when '}'
-              :right_brace
-            when '('
-              :left_paren
-            when ')'
-              :right_paren
-            when ','
-              :comma
-            when /\A[[:digit:]]+\z/
-              :int
-            when /\A[[:digit:]]+\.[[:digit:]]+\z/
-              :float
-            when 'true'
-              :true
-            when 'false'
-              :false
-            when 'on'
-              :on
-            when /\A".*"\z/
-              :string
-            when /\A.+:\z/
-              :key
-            when ''
-              next_token_string = "END OF STREAM"
-              :empty
-            when '...'
-              :spread
-            else
-              :field
-            end
-
-            { type: token, string: next_token_string }
-          end
-
-          def trim_leading_whitespace
-            while is_whitespace?(@query.first)
-              @query.shift
-            end
-          end
-
-          def is_whitespace?(char)
-            char == "\n" || char == " "
-          end
-
-          def is_brace_or_bracket_or_comma?(char)
-            char == "{" || char == "}" || char == "(" || char == ")" || char == ","
-          end
+          GraphQL.parse(query)
+        rescue GraphQL::ParseError
+          GraphQL.parse("query { #{query} }")
         end
       end
     end

--- a/spec/unit/lib/graphql/remote_loader/query_merger_spec.rb
+++ b/spec/unit/lib/graphql/remote_loader/query_merger_spec.rb
@@ -8,7 +8,12 @@ describe GraphQL::RemoteLoader::QueryMerger do
         let(:result) { subject.merge([["foo", 2]]) }
 
         it "returns the expected query" do
-          expect(result).to eq("query { p2foo: foo }")
+          expected_result = <<~GRAPHQL
+            query {
+              p2foo: foo
+            }
+          GRAPHQL
+          expect(result).to eq(expected_result.strip)
         end
       end
 
@@ -16,7 +21,15 @@ describe GraphQL::RemoteLoader::QueryMerger do
         let(:result) { subject.merge([["foo bar { buzz }", 2]]) }
 
         it "returns the expected query" do
-          expect(result).to eq("query { p2foo: foo p2bar: bar { p2buzz: buzz } }")
+          expected_result = <<~GRAPHQL
+            query {
+              p2foo: foo
+              p2bar: bar {
+                p2buzz: buzz
+              }
+            }
+          GRAPHQL
+          expect(result).to eq(expected_result.strip)
         end
       end
 
@@ -24,7 +37,14 @@ describe GraphQL::RemoteLoader::QueryMerger do
         let(:result) { subject.merge([["foo(bar: 5){ buzz }", 2]]) }
 
         it "returns the expected query" do
-          expect(result).to eq("query { p2foo: foo(bar: 5) { p2buzz: buzz } }")
+          expected_result = <<~GRAPHQL
+            query {
+              p2foo: foo(bar: 5) {
+                p2buzz: buzz
+              }
+            }
+          GRAPHQL
+          expect(result).to eq(expected_result.strip)
         end
       end
 
@@ -32,7 +52,16 @@ describe GraphQL::RemoteLoader::QueryMerger do
         let(:result) { subject.merge([["foo { ... on Bar { buzz } }", 2]]) }
 
         it "returns the expected query" do
-          expect(result).to eq("query { p2foo: foo { ... on Bar { p2buzz: buzz } } }")
+          expected_result = <<~GRAPHQL
+            query {
+              p2foo: foo {
+                ... on Bar {
+                  p2buzz: buzz
+                }
+              }
+            }
+          GRAPHQL
+          expect(result).to eq(expected_result.strip)
         end
       end
     end
@@ -42,7 +71,15 @@ describe GraphQL::RemoteLoader::QueryMerger do
         let(:result) { subject.merge([["foo bar", 2], ["buzz bazz", 3]]) }
 
         it "returns the expected query" do
-          expect(result).to eq("query { p2foo: foo p2bar: bar p3buzz: buzz p3bazz: bazz }")
+          expected_result = <<~GRAPHQL
+            query {
+              p3buzz: buzz
+              p3bazz: bazz
+              p2foo: foo
+              p2bar: bar
+            }
+          GRAPHQL
+          expect(result).to eq(expected_result.strip)
         end
       end
 
@@ -50,7 +87,17 @@ describe GraphQL::RemoteLoader::QueryMerger do
         let(:result) { subject.merge([["foo(buzz: 1) { bar }", 2], ["foo(buzz: 2) {  bar }", 3]]) }
 
         it "returns the expected query" do
-          expect(result).to eq("query { p2foo: foo(buzz: 1) { p2bar: bar } p3foo: foo(buzz: 2) { p3bar: bar } }")
+          expected_result = <<~GRAPHQL
+            query {
+              p3foo: foo(buzz: 2) {
+                p3bar: bar
+              }
+              p2foo: foo(buzz: 1) {
+                p2bar: bar
+              }
+            }
+          GRAPHQL
+          expect(result).to eq(expected_result.strip)
         end
       end
 
@@ -58,7 +105,15 @@ describe GraphQL::RemoteLoader::QueryMerger do
         let(:result) { subject.merge([["foo { bar }", 2], ["foo { buzz }", 3]]) }
 
         it "returns the expected query" do
-          expect(result).to eq("query { p6foo: foo { p2bar: bar p3buzz: buzz } }")
+          expected_result = <<~GRAPHQL
+            query {
+              p6foo: foo {
+                p3buzz: buzz
+                p2bar: bar
+              }
+            }
+          GRAPHQL
+          expect(result).to eq(expected_result.strip)
         end
       end
 
@@ -66,7 +121,15 @@ describe GraphQL::RemoteLoader::QueryMerger do
         let(:result) { subject.merge([["foo(buzz: 1) { bar }", 2], ["foo(buzz: 1) {  bar bazz }", 3]]) }
 
         it "returns the expected query" do
-          expect(result).to eq("query { p6foo: foo(buzz: 1) { p6bar: bar p3bazz: bazz } }")
+          expected_result = <<~GRAPHQL
+            query {
+              p6foo: foo(buzz: 1) {
+                p6bar: bar
+                p3bazz: bazz
+              }
+            }
+          GRAPHQL
+          expect(result).to eq(expected_result.strip)
         end
       end
     end


### PR DESCRIPTION
Closes #1 

Now that we're not using my jank parser anymore, we can move forward with supporting more language constructs like directives, variables and fragments.