### PR TITLE
Support aliases

### DIFF
--- a/spec/unit/lib/graphql/remote_loader/loader_spec.rb
+++ b/spec/unit/lib/graphql/remote_loader/loader_spec.rb
@@ -147,4 +147,51 @@ describe GraphQL::RemoteLoader::Loader do
       expect(second["foo"]["buzz"]).to eq("buzz_second_result")
     end
   end
+
+  context "hitting the loader with one field with an alias" do
+    it "returns the correct results and only makes one query" do
+      TestLoader.any_instance.stub(:query).and_return({
+        "p2p3foobar" => "bar_result"
+      })
+      TestLoader.any_instance.should_receive(:query).once
+
+      result = GraphQL::Batch.batch do
+        TestLoader.load("foo: bar")
+      end
+
+      expect(result["foo"]).to eq("bar_result")
+    end
+  end
+
+  context "hitting the loader with fields with overlapping aliases" do
+    it "returns the correct results and only makes one query" do
+      TestLoader.any_instance.stub(:query).and_return({
+        "p2p3foobar" => "bar_result",
+        "p3p4buzzbazz" => "bazz_result"
+      })
+      TestLoader.any_instance.should_receive(:query).once
+
+      first, second = GraphQL::Batch.batch do
+        Promise.all([TestLoader.load("foo: bar"), TestLoader.load("buzz: bazz")])
+      end
+
+      expect(first["foo"]).to eq("bar_result")
+      expect(second["buzz"]).to eq("bazz_result")
+    end
+
+    it "fulfills promises with only the data they asked for" do
+      TestLoader.any_instance.stub(:query).and_return({
+        "p2p3foobar" => "bar_result",
+        "p3p4buzzbazz" => "bazz_result"
+      })
+      TestLoader.any_instance.should_receive(:query).once
+
+      first, second = GraphQL::Batch.batch do
+        Promise.all([TestLoader.load("foo: bar"), TestLoader.load("buzz: bazz")])
+      end
+
+      expect(second["foo"]).to be_nil
+      expect(first["buzz"]).to be_nil
+    end
+  end
 end

--- a/spec/unit/lib/graphql/remote_loader/loader_spec.rb
+++ b/spec/unit/lib/graphql/remote_loader/loader_spec.rb
@@ -151,7 +151,7 @@ describe GraphQL::RemoteLoader::Loader do
   context "hitting the loader with one field with an alias" do
     it "returns the correct results and only makes one query" do
       TestLoader.any_instance.stub(:query).and_return({
-        "p2p3foobar" => "bar_result"
+        "p2foo" => "bar_result"
       })
       TestLoader.any_instance.should_receive(:query).once
 
@@ -166,8 +166,8 @@ describe GraphQL::RemoteLoader::Loader do
   context "hitting the loader with fields with overlapping aliases" do
     it "returns the correct results and only makes one query" do
       TestLoader.any_instance.stub(:query).and_return({
-        "p2p3foobar" => "bar_result",
-        "p3p4buzzbazz" => "bazz_result"
+        "p2foo" => "bar_result",
+        "p3buzz" => "bazz_result"
       })
       TestLoader.any_instance.should_receive(:query).once
 
@@ -181,8 +181,8 @@ describe GraphQL::RemoteLoader::Loader do
 
     it "fulfills promises with only the data they asked for" do
       TestLoader.any_instance.stub(:query).and_return({
-        "p2p3foobar" => "bar_result",
-        "p3p4buzzbazz" => "bazz_result"
+        "p2foo" => "bar_result",
+        "p3buzz" => "bazz_result"
       })
       TestLoader.any_instance.should_receive(:query).once
 

--- a/spec/unit/lib/graphql/remote_loader/query_merger_spec.rb
+++ b/spec/unit/lib/graphql/remote_loader/query_merger_spec.rb
@@ -45,7 +45,7 @@ describe GraphQL::RemoteLoader::QueryMerger do
 
         it "returns the expected query" do
           expected_result = <<~GRAPHQL
-            query{
+            query {
               p2p3foobar: bar
             }
           GRAPHQL
@@ -193,6 +193,34 @@ describe GraphQL::RemoteLoader::QueryMerger do
               query {
                 p3p4buzzbazz: bazz
                 p2p3foobar: bar
+              }
+            GRAPHQL
+            expect(result).to eq(expected_result.strip)
+          end
+        end
+
+        # Notice we do not merge if aliases are differing.
+        context "when there is field name overlap but differing aliases" do
+          let(:result) { subject.merge([["foo: bar", 2], ["buzz: bar", 3]]) }
+
+          it "returns the expected query" do
+            expected_result = <<~GRAPHQL
+              query {
+                p3p4buzzbar: bar
+                p2p3foobar: bar
+              }
+            GRAPHQL
+            expect(result).to eq(expected_result.strip)
+          end
+        end
+
+        context "when there is field name overlap and same aliases" do
+          let(:result) { subject.merge([["foo: bar", 2], ["foo: bar", 3]]) }
+
+          it "returns the expected query" do
+            expected_result = <<~GRAPHQL
+              query {
+                p6p3foobar: bar
               }
             GRAPHQL
             expect(result).to eq(expected_result.strip)

--- a/spec/unit/lib/graphql/remote_loader/query_merger_spec.rb
+++ b/spec/unit/lib/graphql/remote_loader/query_merger_spec.rb
@@ -33,6 +33,26 @@ describe GraphQL::RemoteLoader::QueryMerger do
         end
       end
 
+      context "when there are field aliases" do
+        let(:result) { subject.merge([["foo: bar", 2]]) }
+
+        # When aliases are involved, the computed alias form is
+        # p<prime><computed alias string><field_name>
+        #
+        # where <computed alias string> is
+        #  - "" if no alias
+        #  - p<alias length><alias> otherwise
+
+        it "returns the expected query" do
+          expected_result = <<~GRAPHQL
+            query{
+              p2p3foobar: bar
+            }
+          GRAPHQL
+          expect(result).to eq(expected_result.strip)
+        end
+      end
+
       context "when there are directives" do
         let(:result) { subject.merge([["foo @bar", 2]]) }
 
@@ -161,6 +181,22 @@ describe GraphQL::RemoteLoader::QueryMerger do
             }
           GRAPHQL
           expect(result).to eq(expected_result.strip)
+        end
+      end
+
+      context "when there are aliases" do
+        context "when there is no overlap" do
+          let(:result) { subject.merge([["foo: bar", 2], ["buzz: bazz", 3]]) }
+
+          it "returns the expected query" do
+            expected_result = <<~GRAPHQL
+              query {
+                p3p4buzzbazz: bazz
+                p2p3foobar: bar
+              }
+            GRAPHQL
+            expect(result).to eq(expected_result.strip)
+          end
         end
       end
 

--- a/spec/unit/lib/graphql/remote_loader/query_merger_spec.rb
+++ b/spec/unit/lib/graphql/remote_loader/query_merger_spec.rb
@@ -36,17 +36,10 @@ describe GraphQL::RemoteLoader::QueryMerger do
       context "when there are field aliases" do
         let(:result) { subject.merge([["foo: bar", 2]]) }
 
-        # When aliases are involved, the computed alias form is
-        # p<prime><computed alias string><field_name>
-        #
-        # where <computed alias string> is
-        #  - "" if no alias
-        #  - p<alias length><alias> otherwise
-
         it "returns the expected query" do
           expected_result = <<~GRAPHQL
             query {
-              p2p3foobar: bar
+              p2foo: bar
             }
           GRAPHQL
           expect(result).to eq(expected_result.strip)
@@ -191,8 +184,8 @@ describe GraphQL::RemoteLoader::QueryMerger do
           it "returns the expected query" do
             expected_result = <<~GRAPHQL
               query {
-                p3p4buzzbazz: bazz
-                p2p3foobar: bar
+                p3buzz: bazz
+                p2foo: bar
               }
             GRAPHQL
             expect(result).to eq(expected_result.strip)
@@ -206,8 +199,8 @@ describe GraphQL::RemoteLoader::QueryMerger do
           it "returns the expected query" do
             expected_result = <<~GRAPHQL
               query {
-                p3p4buzzbar: bar
-                p2p3foobar: bar
+                p3buzz: bar
+                p2foo: bar
               }
             GRAPHQL
             expect(result).to eq(expected_result.strip)
@@ -220,7 +213,7 @@ describe GraphQL::RemoteLoader::QueryMerger do
           it "returns the expected query" do
             expected_result = <<~GRAPHQL
               query {
-                p6p3foobar: bar
+                p6foo: bar
               }
             GRAPHQL
             expect(result).to eq(expected_result.strip)


### PR DESCRIPTION
Add support for aliases in loaded queries.

```graphql
query{
  foo: bar {
    buzz: bazz
  }
}
```