### PR TITLE
Correctly fulfill errors to promises using path key

### DIFF
--- a/lib/graphql/remote_loader/loader.rb
+++ b/lib/graphql/remote_loader/loader.rb
@@ -38,7 +38,7 @@ module GraphQL
         data, errors = response["data"], response["errors"]
 
         queries_and_primes.each do |query, prime|
-          fulfill([query, prime], filter_keys_on_response(data, prime))
+          fulfill([query, prime], {"data" => filter_keys_on_response(data, prime)})
         end
       end
 

--- a/lib/graphql/remote_loader/loader.rb
+++ b/lib/graphql/remote_loader/loader.rb
@@ -33,10 +33,12 @@ module GraphQL
 
       def perform(queries_and_primes)
         query_string = QueryMerger.merge(queries_and_primes)
-        response = query(query_string)
+        response = query(query_string).to_h
+
+        data, errors = response["data"], response["errors"]
 
         queries_and_primes.each do |query, prime|
-          fulfill([query, prime], filter_keys_on_response(response.to_h, prime))
+          fulfill([query, prime], filter_keys_on_response(data, prime))
         end
       end
 

--- a/spec/unit/lib/graphql/remote_loader/loader_spec.rb
+++ b/spec/unit/lib/graphql/remote_loader/loader_spec.rb
@@ -22,7 +22,7 @@ describe GraphQL::RemoteLoader::Loader do
         TestLoader.load("test")
       end
 
-      expect(results["test"]).to eq("test_result")
+      expect(results["data"]["test"]).to eq("test_result")
     end
   end
 
@@ -35,8 +35,8 @@ describe GraphQL::RemoteLoader::Loader do
         Promise.all([TestLoader.load("test"), TestLoader.load("test")])
       end
 
-      expect(first["test"]).to eq("test_result")
-      expect(second["test"]).to eq("test_result")
+      expect(first["data"]["test"]).to eq("test_result")
+      expect(second["data"]["test"]).to eq("test_result")
     end
   end
 
@@ -54,8 +54,8 @@ describe GraphQL::RemoteLoader::Loader do
         Promise.all([TestLoader.load("foo"), TestLoader.load("bar")])
       end
 
-      expect(first["foo"]).to eq("foo_result")
-      expect(second["bar"]).to eq("bar_result")
+      expect(first["data"]["foo"]).to eq("foo_result")
+      expect(second["data"]["bar"]).to eq("bar_result")
     end
 
     it "fulfills promises with no un-requested data" do
@@ -71,8 +71,8 @@ describe GraphQL::RemoteLoader::Loader do
         Promise.all([TestLoader.load("foo { bar }"), TestLoader.load("foo { buzz }")])
       end
 
-      expect(first["bar"]).to be_nil
-      expect(second["foo"]).to be_nil
+      expect(first["data"]["bar"]).to be_nil
+      expect(second["data"]["foo"]).to be_nil
     end
   end
 
@@ -89,8 +89,8 @@ describe GraphQL::RemoteLoader::Loader do
         TestLoader.load("foo { bar }")
       end
 
-      expect(result["foo"][0]["bar"]).to eq(5)
-      expect(result["foo"][1]["bar"]).to eq(6)
+      expect(result["data"]["foo"][0]["bar"]).to eq(5)
+      expect(result["data"]["foo"][1]["bar"]).to eq(6)
     end
   end
 
@@ -110,8 +110,8 @@ describe GraphQL::RemoteLoader::Loader do
         Promise.all([TestLoader.load("foo { bar }"), TestLoader.load("foo { buzz }")])
       end
 
-      expect(first["foo"]["bar"]).to eq("bar_result")
-      expect(second["foo"]["buzz"]).to eq("buzz_result")
+      expect(first["data"]["foo"]["bar"]).to eq("bar_result")
+      expect(second["data"]["foo"]["buzz"]).to eq("buzz_result")
     end
 
     it "fulfills promises with no un-requested data" do
@@ -132,8 +132,8 @@ describe GraphQL::RemoteLoader::Loader do
       # These are both nil because the first request asked for foo,buzz and the second
       # asked for foo,bar. foo,buzz should not be exposed in the first result,
       # and foo,bar should not be exposed in the second result.
-      expect(first["foo"]["buzz"]).to be_nil
-      expect(second["foo"]["bar"]).to be_nil
+      expect(first["data"]["foo"]["buzz"]).to be_nil
+      expect(second["data"]["foo"]["bar"]).to be_nil
     end
   end
 
@@ -155,8 +155,8 @@ describe GraphQL::RemoteLoader::Loader do
         Promise.all([TestLoader.load("foo(bar: 1) { buzz }"), TestLoader.load("foo(bar: 2){ buzz }")])
       end
 
-      expect(first["foo"]["buzz"]).to eq("buzz_first_result")
-      expect(second["foo"]["buzz"]).to eq("buzz_second_result")
+      expect(first["data"]["foo"]["buzz"]).to eq("buzz_first_result")
+      expect(second["data"]["foo"]["buzz"]).to eq("buzz_second_result")
     end
   end
 
@@ -173,7 +173,7 @@ describe GraphQL::RemoteLoader::Loader do
         TestLoader.load("foo: bar")
       end
 
-      expect(result["foo"]).to eq("bar_result")
+      expect(result["data"]["foo"]).to eq("bar_result")
     end
   end
 
@@ -191,8 +191,8 @@ describe GraphQL::RemoteLoader::Loader do
         Promise.all([TestLoader.load("foo: bar"), TestLoader.load("buzz: bazz")])
       end
 
-      expect(first["foo"]).to eq("bar_result")
-      expect(second["buzz"]).to eq("bazz_result")
+      expect(first["data"]["foo"]).to eq("bar_result")
+      expect(second["data"]["buzz"]).to eq("bazz_result")
     end
 
     it "fulfills promises with only the data they asked for" do
@@ -208,8 +208,8 @@ describe GraphQL::RemoteLoader::Loader do
         Promise.all([TestLoader.load("foo: bar"), TestLoader.load("buzz: bazz")])
       end
 
-      expect(second["foo"]).to be_nil
-      expect(first["buzz"]).to be_nil
+      expect(second["data"]["foo"]).to be_nil
+      expect(first["data"]["buzz"]).to be_nil
     end
   end
 end

--- a/spec/unit/lib/graphql/remote_loader/loader_spec.rb
+++ b/spec/unit/lib/graphql/remote_loader/loader_spec.rb
@@ -15,7 +15,7 @@ describe GraphQL::RemoteLoader::Loader do
 
   context "hitting the loader once" do
     it "returns the correct results and only makes one query" do
-      TestLoader.any_instance.stub(:query).and_return({"p2test" => "test_result"})
+      TestLoader.any_instance.stub(:query).and_return({"data" => {"p2test" => "test_result"}})
       TestLoader.any_instance.should_receive(:query).once
 
       results = GraphQL::Batch.batch do
@@ -28,7 +28,7 @@ describe GraphQL::RemoteLoader::Loader do
 
   context "hitting the loader multiple times for one field" do
     it "returns the correct results and only makes one query" do
-      TestLoader.any_instance.stub(:query).and_return({"p6test" => "test_result"})
+      TestLoader.any_instance.stub(:query).and_return({"data" => {"p6test" => "test_result"}})
       TestLoader.any_instance.should_receive(:query).once
 
       first, second = GraphQL::Batch.batch do
@@ -43,8 +43,10 @@ describe GraphQL::RemoteLoader::Loader do
   context "hitting the loader with multiple fields" do
     it "returns the correct results and only makes one query" do
       TestLoader.any_instance.stub(:query).and_return({
-        "p2foo" => "foo_result",
-        "p3bar" => "bar_result"
+        "data" => {
+          "p2foo" => "foo_result",
+          "p3bar" => "bar_result"
+        }
       })
       TestLoader.any_instance.should_receive(:query).once
 
@@ -58,8 +60,10 @@ describe GraphQL::RemoteLoader::Loader do
 
     it "fulfills promises with no un-requested data" do
       TestLoader.any_instance.stub(:query).and_return({
-        "p2foo" => "foo_result",
-        "p3bar" => "bar_result"
+        "data" => {
+          "p2foo" => "foo_result",
+          "p3bar" => "bar_result"
+        }
       })
       TestLoader.any_instance.should_receive(:query).once
 
@@ -75,7 +79,9 @@ describe GraphQL::RemoteLoader::Loader do
   context "hitting the loader with an array" do
     it "returns the correct results and only makes one query" do
       TestLoader.any_instance.stub(:query).and_return({
-        "p2foo" => [{"p2bar" => 5}, {"p2bar" => 6}]
+        "data" => {
+          "p2foo" => [{"p2bar" => 5}, {"p2bar" => 6}]
+        }
       })
       TestLoader.any_instance.should_receive(:query).once
 
@@ -91,9 +97,11 @@ describe GraphQL::RemoteLoader::Loader do
   context "hitting the loader with overlapping fields with different sub-selections" do
     it "returns the correct results and only makes one query" do
       TestLoader.any_instance.stub(:query).and_return({
-        "p6foo" => {
-          "p2bar" => "bar_result",
-          "p3buzz" => "buzz_result"
+        "data" => {
+          "p6foo" => {
+            "p2bar" => "bar_result",
+            "p3buzz" => "buzz_result"
+          }
         }
       })
       TestLoader.any_instance.should_receive(:query).once
@@ -108,9 +116,11 @@ describe GraphQL::RemoteLoader::Loader do
 
     it "fulfills promises with no un-requested data" do
       TestLoader.any_instance.stub(:query).and_return({
-        "p6foo" => {
-          "p2bar" => "bar_result",
-          "p3buzz" => "buzz_result"
+        "data" => {
+          "p6foo" => {
+            "p2bar" => "bar_result",
+            "p3buzz" => "buzz_result"
+          }
         }
       })
       TestLoader.any_instance.should_receive(:query).once
@@ -130,11 +140,13 @@ describe GraphQL::RemoteLoader::Loader do
   context "hitting the loader with fields with differing argument values" do
     it "returns the correct results and only makes one query" do
       TestLoader.any_instance.stub(:query).and_return({
-        "p2foo" => {
-          "p2buzz" => "buzz_first_result"
-        },
-        "p3foo" => {
-          "p3buzz" => "buzz_second_result"
+        "data" => {
+          "p2foo" => {
+            "p2buzz" => "buzz_first_result"
+          },
+          "p3foo" => {
+            "p3buzz" => "buzz_second_result"
+          }
         }
       })
       TestLoader.any_instance.should_receive(:query).once
@@ -151,7 +163,9 @@ describe GraphQL::RemoteLoader::Loader do
   context "hitting the loader with one field with an alias" do
     it "returns the correct results and only makes one query" do
       TestLoader.any_instance.stub(:query).and_return({
-        "p2foo" => "bar_result"
+        "data" => {
+          "p2foo" => "bar_result"
+        }
       })
       TestLoader.any_instance.should_receive(:query).once
 
@@ -166,8 +180,10 @@ describe GraphQL::RemoteLoader::Loader do
   context "hitting the loader with fields with overlapping aliases" do
     it "returns the correct results and only makes one query" do
       TestLoader.any_instance.stub(:query).and_return({
-        "p2foo" => "bar_result",
-        "p3buzz" => "bazz_result"
+        "data" => {
+          "p2foo" => "bar_result",
+          "p3buzz" => "bazz_result"
+        }
       })
       TestLoader.any_instance.should_receive(:query).once
 
@@ -181,8 +197,10 @@ describe GraphQL::RemoteLoader::Loader do
 
     it "fulfills promises with only the data they asked for" do
       TestLoader.any_instance.stub(:query).and_return({
-        "p2foo" => "bar_result",
-        "p3buzz" => "bazz_result"
+        "data" => {
+          "p2foo" => "bar_result",
+          "p3buzz" => "bazz_result"
+        }
       })
       TestLoader.any_instance.should_receive(:query).once
 

--- a/spec/unit/lib/graphql/remote_loader/loader_spec.rb
+++ b/spec/unit/lib/graphql/remote_loader/loader_spec.rb
@@ -237,6 +237,26 @@ describe GraphQL::RemoteLoader::Loader do
       end
     end
 
+    context "when data key isn't present" do
+      it "fulfills promise with error map if it requested the field that errored" do
+        TestLoader.any_instance.stub(:query).and_return({
+          "errors" => [{
+            "message" => "Something went wrong!",
+            "path" => ["p2foo"]
+          }]
+        })
+        TestLoader.any_instance.should_receive(:query).once
+
+        result = GraphQL::Batch.batch do
+          TestLoader.load("foo")
+        end
+
+        expect(result["data"]).to be_nil
+        expect(result["errors"][0]["message"]).to eq("Something went wrong!")
+        expect(result["errors"][0]["path"]).to eq(["foo"])
+      end
+    end
+
     context "when errored field is asked for multiple times" do
       it "fulfills promise with error map if it requested the field that errored" do
         TestLoader.any_instance.stub(:query).and_return({


### PR DESCRIPTION
Closes #7 

A couple of big changes with this PR:

1. Response hashes returned to `#load` now use the top level keys `data` and `errors`, instead of just showing the keys in the `data` hash.
2. Implementations of `#query` now must return a hash that has a top level `data` or `errors` key, according to the spec.
3. Queries made using the loader will now be returned errors raised in fields requested. Errors present in another invocation of the loader will not be present in the returned response object.

E.g.

```ruby
# Query 1
Loader.load("viewer { login }")
...
# Query 2
Loader.load("viewer { thisWillError }")
```

Batched query(aliases are implementation details and not important):
```graphql
query {
  viewer {
    someAlias: login
    someOtherAlias: thisWillError
  }
}
```

Batched query response:
```json
{ 
  "data": {
    "viewer": {
      "login": "d12",
      "thisWillError": null
    }
  },
  "errors": [{
    "message": "Something went wrong",
    "path": ["viewer", "thisWillError"]
  }]
}
```

Query 1 response:
```
{ 
  "data": {
    "viewer": {
      "login": "d12"
    }
  }
}
```

Query 2 response:
```json
{
  "errors": [{
    "message": "Something went wrong",
    "path": ["viewer", "thisWillError"]
  }]
}
```

With this PR, this gem finally has the features needed to be reasonably usable in another app.