### PR TITLE
Bump gem version to 1.0.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql-remote_loader (0.0.5)
+    graphql-remote_loader (1.0.0)
       graphql (~> 1.6)
       graphql-batch (~> 0.3)
 

--- a/lib/graphql/remote_loader/version.rb
+++ b/lib/graphql/remote_loader/version.rb
@@ -1,5 +1,5 @@
 module GraphQL
   module RemoteLoader
-    VERSION = "0.0.5"
+    VERSION = "1.0.0"
   end
 end


### PR DESCRIPTION
Bump from 0.0.5 to 1.0.0 not because this version is way better than the last or anything. There are big breaking changes described in #14 though, so applications may need to be modified when bumping to 1.0.0.