### PR TITLE
Add load_value

### DIFF
--- a/spec/unit/lib/graphql/remote_loader/loader_spec.rb
+++ b/spec/unit/lib/graphql/remote_loader/loader_spec.rb
@@ -282,4 +282,46 @@ describe GraphQL::RemoteLoader::Loader do
       end
     end
   end
+
+  context "#load_value" do
+    context "when no errors" do
+      it "returns value" do
+        TestLoader.any_instance.stub(:query).and_return({
+          "data" => {
+            "p2foo" => {
+              "p2bar" => 5
+            }
+          }
+        })
+        TestLoader.any_instance.should_receive(:query).once
+
+        result = GraphQL::Batch.batch do
+          TestLoader.load_value("foo", "bar")
+        end
+
+        expect(result).to eq(5)
+      end
+    end
+
+    context "when there are errors" do
+      it "returns nil" do
+        TestLoader.any_instance.stub(:query).and_return({
+          "data" => {
+            "p2foo" => nil
+          },
+          "errors" => [{
+            "message" => "Something went wrong!",
+            "path" => ["p2foo", "p2bar"]
+          }]
+        })
+        TestLoader.any_instance.should_receive(:query).once
+
+        result = GraphQL::Batch.batch do
+          TestLoader.load_value("foo", "bar")
+        end
+
+        expect(result).to be_nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
Closes #17 

This creates a shorthand for creating a field that uses unprocessed data backed from a remote loader.

Before:

```
GitHubLoader.load("viewer { login }").then do |results|
  results["data"]["viewer"]["login"] unless results["errors"].present?
end
```

Now:

```
GitHubLoader.load_value("viewer", "login")
```

This will just return nil if `results["errors"]` is present. `#load` should be used for more robust error handling.

Thanks @rmosolgo for the API suggestion! ✨ 