### PR TITLE
Improve test coverage and remove some redundant tests

### DIFF
--- a/lib/graphql/remote_loader/loader.rb
+++ b/lib/graphql/remote_loader/loader.rb
@@ -68,7 +68,7 @@ module GraphQL
       private
 
       def perform(queries_and_primes)
-        query_string = QueryMerger.merge(queries_and_primes)
+        query_string = QueryMerger.merge(queries_and_primes).gsub(/\s+/, " ")
         context = queries_and_primes[-1][-1]
         response = query(query_string, context: context).to_h
 

--- a/spec/unit/lib/graphql/remote_loader/loader_spec.rb
+++ b/spec/unit/lib/graphql/remote_loader/loader_spec.rb
@@ -14,8 +14,9 @@ describe GraphQL::RemoteLoader::Loader do
 
   context "hitting the loader once" do
     it "returns the correct results and only makes one query" do
-      TestLoader.any_instance.stub(:query).and_return({"data" => {"p2test" => "test_result"}})
       TestLoader.any_instance.should_receive(:query).once
+        .with("query { p2test: test }", anything)
+        .and_return({"data" => {"p2test" => "test_result"}})
 
       results = GraphQL::Batch.batch do
         TestLoader.load("test")
@@ -27,8 +28,9 @@ describe GraphQL::RemoteLoader::Loader do
 
   context "hitting the loader multiple times for one field" do
     it "returns the correct results and only makes one query" do
-      TestLoader.any_instance.stub(:query).and_return({"data" => {"p6test" => "test_result"}})
       TestLoader.any_instance.should_receive(:query).once
+        .with("query { p6test: test }", anything)
+        .and_return({"data" => {"p6test" => "test_result"}})
 
       first, second = GraphQL::Batch.batch do
         Promise.all([TestLoader.load("test"), TestLoader.load("test")])
@@ -41,13 +43,14 @@ describe GraphQL::RemoteLoader::Loader do
 
   context "hitting the loader with multiple fields" do
     it "returns the correct results and only makes one query" do
-      TestLoader.any_instance.stub(:query).and_return({
-        "data" => {
-          "p2foo" => "foo_result",
-          "p3bar" => "bar_result"
-        }
-      })
       TestLoader.any_instance.should_receive(:query).once
+        .with("query { p3bar: bar p2foo: foo }", anything)
+        .and_return({
+          "data" => {
+            "p2foo" => "foo_result",
+            "p3bar" => "bar_result"
+          }
+        })
 
       first, second = GraphQL::Batch.batch do
         Promise.all([TestLoader.load("foo"), TestLoader.load("bar")])
@@ -55,21 +58,8 @@ describe GraphQL::RemoteLoader::Loader do
 
       expect(first["data"]["foo"]).to eq("foo_result")
       expect(second["data"]["bar"]).to eq("bar_result")
-    end
 
-    it "fulfills promises with no un-requested data" do
-      TestLoader.any_instance.stub(:query).and_return({
-        "data" => {
-          "p2foo" => "foo_result",
-          "p3bar" => "bar_result"
-        }
-      })
-      TestLoader.any_instance.should_receive(:query).once
-
-      first, second = GraphQL::Batch.batch do
-        Promise.all([TestLoader.load("foo { bar }"), TestLoader.load("foo { buzz }")])
-      end
-
+      # un-requested data should not be present
       expect(first["data"]["bar"]).to be_nil
       expect(second["data"]["foo"]).to be_nil
     end
@@ -77,12 +67,13 @@ describe GraphQL::RemoteLoader::Loader do
 
   context "hitting the loader with an array" do
     it "returns the correct results and only makes one query" do
-      TestLoader.any_instance.stub(:query).and_return({
-        "data" => {
-          "p2foo" => [{"p2bar" => 5}, {"p2bar" => 6}]
-        }
-      })
       TestLoader.any_instance.should_receive(:query).once
+        .with("query { p2foo: foo { p2bar: bar } }", anything)
+        .and_return({
+          "data" => {
+            "p2foo" => [{"p2bar" => 5}, {"p2bar" => 6}]
+          }
+        })
 
       result = GraphQL::Batch.batch do
         TestLoader.load("foo { bar }")
@@ -95,15 +86,16 @@ describe GraphQL::RemoteLoader::Loader do
 
   context "hitting the loader with overlapping fields with different sub-selections" do
     it "returns the correct results and only makes one query" do
-      TestLoader.any_instance.stub(:query).and_return({
-        "data" => {
-          "p6foo" => {
-            "p2bar" => "bar_result",
-            "p3buzz" => "buzz_result"
-          }
-        }
-      })
       TestLoader.any_instance.should_receive(:query).once
+        .with("query { p6foo: foo { p3buzz: buzz p2bar: bar } }", anything)
+        .and_return({
+          "data" => {
+            "p6foo" => {
+              "p2bar" => "bar_result",
+              "p3buzz" => "buzz_result"
+            }
+          }
+        })
 
       first, second = GraphQL::Batch.batch do
         Promise.all([TestLoader.load("foo { bar }"), TestLoader.load("foo { buzz }")])
@@ -111,22 +103,6 @@ describe GraphQL::RemoteLoader::Loader do
 
       expect(first["data"]["foo"]["bar"]).to eq("bar_result")
       expect(second["data"]["foo"]["buzz"]).to eq("buzz_result")
-    end
-
-    it "fulfills promises with no un-requested data" do
-      TestLoader.any_instance.stub(:query).and_return({
-        "data" => {
-          "p6foo" => {
-            "p2bar" => "bar_result",
-            "p3buzz" => "buzz_result"
-          }
-        }
-      })
-      TestLoader.any_instance.should_receive(:query).once
-
-      first, second = GraphQL::Batch.batch do
-        Promise.all([TestLoader.load("foo { bar }"), TestLoader.load("foo { buzz }")])
-      end
 
       # These are both nil because the first request asked for foo,buzz and the second
       # asked for foo,bar. foo,buzz should not be exposed in the first result,
@@ -138,17 +114,18 @@ describe GraphQL::RemoteLoader::Loader do
 
   context "hitting the loader with fields with differing argument values" do
     it "returns the correct results and only makes one query" do
-      TestLoader.any_instance.stub(:query).and_return({
-        "data" => {
-          "p2foo" => {
-            "p2buzz" => "buzz_first_result"
-          },
-          "p3foo" => {
-            "p3buzz" => "buzz_second_result"
-          }
-        }
-      })
       TestLoader.any_instance.should_receive(:query).once
+        .with("query { p3foo: foo(bar: 2) { p3buzz: buzz } p2foo: foo(bar: 1) { p2buzz: buzz } }", anything)
+        .and_return({
+          "data" => {
+            "p2foo" => {
+              "p2buzz" => "buzz_first_result"
+            },
+            "p3foo" => {
+              "p3buzz" => "buzz_second_result"
+            }
+          }
+        })
 
       first, second = GraphQL::Batch.batch do
         Promise.all([TestLoader.load("foo(bar: 1) { buzz }"), TestLoader.load("foo(bar: 2){ buzz }")])
@@ -161,12 +138,13 @@ describe GraphQL::RemoteLoader::Loader do
 
   context "hitting the loader with one field with an alias" do
     it "returns the correct results and only makes one query" do
-      TestLoader.any_instance.stub(:query).and_return({
-        "data" => {
-          "p2foo" => "bar_result"
-        }
-      })
       TestLoader.any_instance.should_receive(:query).once
+        .with("query { p2foo: bar }", anything)
+        .and_return({
+          "data" => {
+            "p2foo" => "bar_result"
+          }
+        })
 
       result = GraphQL::Batch.batch do
         TestLoader.load("foo: bar")
@@ -178,30 +156,32 @@ describe GraphQL::RemoteLoader::Loader do
 
   context "hitting the loader with fields with overlapping aliases" do
     it "returns the correct results and only makes one query" do
-      TestLoader.any_instance.stub(:query).and_return({
-        "data" => {
-          "p2foo" => "bar_result",
-          "p3buzz" => "bazz_result"
-        }
-      })
       TestLoader.any_instance.should_receive(:query).once
+        .with("query { p3foo: bazz p2foo: bar }", anything)
+        .and_return({
+          "data" => {
+            "p2foo" => "bar_result",
+            "p3foo" => "bazz_result"
+          }
+        })
 
       first, second = GraphQL::Batch.batch do
-        Promise.all([TestLoader.load("foo: bar"), TestLoader.load("buzz: bazz")])
+        Promise.all([TestLoader.load("foo: bar"), TestLoader.load("foo: bazz")])
       end
 
       expect(first["data"]["foo"]).to eq("bar_result")
-      expect(second["data"]["buzz"]).to eq("bazz_result")
+      expect(second["data"]["foo"]).to eq("bazz_result")
     end
 
     it "fulfills promises with only the data they asked for" do
-      TestLoader.any_instance.stub(:query).and_return({
-        "data" => {
-          "p2foo" => "bar_result",
-          "p3buzz" => "bazz_result"
-        }
-      })
       TestLoader.any_instance.should_receive(:query).once
+        .with("query { p3buzz: bazz p2foo: bar }", anything)
+        .and_return({
+          "data" => {
+            "p2foo" => "bar_result",
+            "p3buzz" => "bazz_result"
+          }
+        })
 
       first, second = GraphQL::Batch.batch do
         Promise.all([TestLoader.load("foo: bar"), TestLoader.load("buzz: bazz")])
@@ -215,16 +195,17 @@ describe GraphQL::RemoteLoader::Loader do
   context "when errors are returned" do
     context "when errored field is asked for once" do
       it "fulfills promise with error map if it requested the field that errored" do
-        TestLoader.any_instance.stub(:query).and_return({
-          "data" => {
-            "p2foo" => nil
-          },
-          "errors" => [{
-            "message" => "Something went wrong!",
-            "path" => ["p2foo"]
-          }]
-        })
         TestLoader.any_instance.should_receive(:query).once
+          .with("query { p2foo: foo }", anything)
+          .and_return({
+            "data" => {
+              "p2foo" => nil
+            },
+            "errors" => [{
+              "message" => "Something went wrong!",
+              "path" => ["p2foo"]
+            }]
+          })
 
         result = GraphQL::Batch.batch do
           TestLoader.load("foo")
@@ -238,13 +219,14 @@ describe GraphQL::RemoteLoader::Loader do
 
     context "when data key isn't present" do
       it "fulfills promise with error map if it requested the field that errored" do
-        TestLoader.any_instance.stub(:query).and_return({
-          "errors" => [{
-            "message" => "Something went wrong!",
-            "path" => ["p2foo"]
-          }]
-        })
         TestLoader.any_instance.should_receive(:query).once
+          .with("query { p2foo: foo }", anything)
+          .and_return({
+            "errors" => [{
+              "message" => "Something went wrong!",
+              "path" => ["p2foo"]
+            }]
+          })
 
         result = GraphQL::Batch.batch do
           TestLoader.load("foo")
@@ -258,16 +240,17 @@ describe GraphQL::RemoteLoader::Loader do
 
     context "when errored field is asked for multiple times" do
       it "fulfills promise with error map if it requested the field that errored" do
-        TestLoader.any_instance.stub(:query).and_return({
-          "data" => {
-            "p2foo" => nil
-          },
-          "errors" => [{
-            "message" => "Something went wrong!",
-            "path" => ["p6foo"]
-          }]
-        })
         TestLoader.any_instance.should_receive(:query).once
+          .with("query { p6foo: foo }", anything)
+          .and_return({
+            "data" => {
+              "p6foo" => nil
+            },
+            "errors" => [{
+              "message" => "Something went wrong!",
+              "path" => ["p6foo"]
+            }]
+          })
 
         results = GraphQL::Batch.batch do
           Promise.all([TestLoader.load("foo"), TestLoader.load("foo")])
@@ -284,16 +267,15 @@ describe GraphQL::RemoteLoader::Loader do
 
   context "#load_on_relay_node" do
     it "returns value" do
-      TestLoader.any_instance.stub(:query).and_return({
-        "data" => {
-          "p2node" => {
-            "p2viewer" => "foo"
+      TestLoader.any_instance.should_receive(:query).once
+        .with("query { p2node: node(id: \"id\") { ... on Type { p2viewer: viewer } } }", anything)
+        .and_return({
+          "data" => {
+            "p2node" => {
+              "p2viewer" => "foo"
+            }
           }
-        }
-      })
-      TestLoader.any_instance.should_receive(:query)
-        .with("query {\n  p2node: node(id: \"id\") {\n    ... on Type {\n      p2viewer: viewer\n    }\n  }\n}", context: {})
-        .once
+        })
 
       result = GraphQL::Batch.batch do
         TestLoader.load_on_relay_node("id", "Type", "viewer")
@@ -306,14 +288,15 @@ describe GraphQL::RemoteLoader::Loader do
   context "#load_value" do
     context "when no errors" do
       it "returns value" do
-        TestLoader.any_instance.stub(:query).and_return({
-          "data" => {
-            "p2foo" => {
-              "p2bar" => 5
-            }
-          }
-        })
         TestLoader.any_instance.should_receive(:query).once
+          .with("query { p2foo: foo { p2bar: bar } }", anything)
+          .and_return({
+            "data" => {
+              "p2foo" => {
+                "p2bar" => 5
+              }
+            }
+          })
 
         result = GraphQL::Batch.batch do
           TestLoader.load_value("foo", "bar")
@@ -325,21 +308,23 @@ describe GraphQL::RemoteLoader::Loader do
 
     context "when there are errors" do
       it "returns nil" do
-        TestLoader.any_instance.stub(:query).and_return({
-          "data" => {
-            "p2foo" => nil
-          },
-          "errors" => [{
-            "message" => "Something went wrong!",
-            "path" => ["p2foo", "p2bar"]
-          }]
-        })
         TestLoader.any_instance.should_receive(:query).once
+          .with("query { p2foo: foo { p2bar: bar } }", anything)
+          .and_return({
+            "data" => {
+              "p2foo" => nil
+            },
+            "errors" => [{
+              "message" => "Something went wrong!",
+              "path" => ["p2foo", "p2bar"]
+            }]
+          })
 
         result = GraphQL::Batch.batch do
           TestLoader.load_value("foo", "bar")
         end
 
+        # load_value does not pass along errors. Perhaps it should raise in future versions?
         expect(result).to be_nil
       end
     end


### PR DESCRIPTION
We now make assertions on what is passed to `query`, drastically improving our test coverage here. 