### PR TITLE
Variable interpolation support

### DIFF
--- a/lib/graphql/remote_loader/loader.rb
+++ b/lib/graphql/remote_loader/loader.rb
@@ -11,7 +11,7 @@ module GraphQL
       # a) Avoid name collisions in the generated query
       # b) Determine which fields in the result JSON should be
       #    handed fulfilled to each promise
-      def self.load(query, context: {})
+      def self.load(query, context: {}, variables: {})
         @index ||= 1
         @index += 1
 

--- a/spec/unit/lib/graphql/remote_loader/loader_spec.rb
+++ b/spec/unit/lib/graphql/remote_loader/loader_spec.rb
@@ -153,6 +153,22 @@ describe GraphQL::RemoteLoader::Loader do
 
       expect(results["data"]["foo"]).to eq("foo_result")
     end
+
+    it "interpolates other variables correctly" do
+      TestLoader.any_instance.should_receive(:query).once
+        .with("query { p2foo: foo(bar: \"Object\") }", anything)
+        .and_return({
+          "data" => {
+            "p2foo" => "foo_result"
+          }
+        })
+
+      results = GraphQL::Batch.batch do
+        TestLoader.load("foo(bar: $my_variable)", variables: { my_variable: Object })
+      end
+
+      expect(results["data"]["foo"]).to eq("foo_result")
+    end
   end
 
   context "hitting the loader with an array" do

--- a/spec/unit/lib/graphql/remote_loader/loader_spec.rb
+++ b/spec/unit/lib/graphql/remote_loader/loader_spec.rb
@@ -65,6 +65,24 @@ describe GraphQL::RemoteLoader::Loader do
     end
   end
 
+  context "when variables are provided" do
+    it "interpolates variables" do
+      TestLoader.any_instance.should_receive(:query).once
+        .with("query { p2foo: foo(bar: 5) }", anything)
+        .and_return({
+          "data" => {
+            "p2foo" => "foo_result"
+          }
+        })
+
+      results = GraphQL::Batch.batch do
+        TestLoader.load("foo(bar: $my_variable)", variables: { my_variable: 5 })
+      end
+
+      expect(results["data"]["foo"]).to eq("foo_result")
+    end
+  end
+
   context "hitting the loader with an array" do
     it "returns the correct results and only makes one query" do
       TestLoader.any_instance.should_receive(:query).once


### PR DESCRIPTION
Usage:

```ruby
my_query = <<~GRAPHQL
  repositories(first: $first, after: $after){ 
    edges{
      cursor
      node { id }
    }
  }
GRAPHQL

GitHubLoader.load(my_query, variables: { first: first, after: after }).then do |results|
  # handle results
end 
```

We now provide variable support via query interpolation. Strings are escaped using `#inspect`, Integers, Floats and Booleans are directly interpolated. Other types are coerced to strings then treated as Strings (to prevent GraphQL query injection by user input).