### PR TITLE
Disallow GraphQL 1.9 until we fix merging in 1.9

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     graphql-remote_loader (1.0.4)
-      graphql (~> 1.6)
+      graphql (>= 1.6, < 1.9)
       graphql-batch (~> 0.3)
 
 GEM
@@ -11,9 +11,9 @@ GEM
     byebug (10.0.2)
     coderay (1.1.2)
     diff-lcs (1.3)
-    graphql (1.8.11)
-    graphql-batch (0.3.10)
-      graphql (>= 0.8, < 2)
+    graphql (1.8.17)
+    graphql-batch (0.4.0)
+      graphql (>= 1.3, < 2)
       promise.rb (~> 0.7.2)
     method_source (0.9.1)
     promise.rb (0.7.4)
@@ -49,4 +49,4 @@ DEPENDENCIES
   rspec (~> 3.6)
 
 BUNDLED WITH
-   1.15.4
+   1.16.1

--- a/graphql-remote_loader.gemspec
+++ b/graphql-remote_loader.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   # spec.executables   = [""]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "graphql", "~> 1.6"
+  spec.add_dependency "graphql", ">=1.6", "<1.9"
   spec.add_dependency "graphql-batch", "~> 0.3"
 
   spec.add_development_dependency "bundler", "~> 1.14"


### PR DESCRIPTION
cc https://github.com/d12/graphql-remote_loader/issues/27

Until we redo query merging, this gem won't work with GraphQL 1.9. Specify `<1.9` in the Gem dependency list.