### PR TITLE
Fix gem for graphql-ruby >= 1.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,5 @@
 language: ruby
+# Work around an issue where bundler isn't installed correctly on Ruby 2.5.
+# We should remove this once Travis uses Ruby 2.6 by default.
+rvm: 2.6
 script: bundle exec rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     graphql-remote_loader (1.0.4)
-      graphql (>= 1.6, < 1.9)
+      graphql (~> 1.9)
       graphql-batch (~> 0.3)
 
 GEM
@@ -11,8 +11,8 @@ GEM
     byebug (10.0.2)
     coderay (1.1.2)
     diff-lcs (1.3)
-    graphql (1.8.17)
-    graphql-batch (0.4.0)
+    graphql (1.9.12)
+    graphql-batch (0.4.1)
       graphql (>= 1.3, < 2)
       promise.rb (~> 0.7.2)
     method_source (0.9.1)
@@ -42,11 +42,11 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundler (~> 1.14)
+  bundler (~> 2.0)
   graphql-remote_loader!
   pry-byebug (~> 3.4)
   rake (~> 10.0)
   rspec (~> 3.6)
 
 BUNDLED WITH
-   1.16.1
+   2.0.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    graphql-remote_loader (1.0.4)
+    graphql-remote_loader (1.0.5)
       graphql (~> 1.9)
       graphql-batch (~> 0.3)
 

--- a/graphql-remote_loader.gemspec
+++ b/graphql-remote_loader.gemspec
@@ -21,10 +21,10 @@ Gem::Specification.new do |spec|
   # spec.executables   = [""]
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "graphql", ">=1.6", "<1.9"
+  spec.add_dependency "graphql", "~> 1.9"
   spec.add_dependency "graphql-batch", "~> 0.3"
 
-  spec.add_development_dependency "bundler", "~> 1.14"
+  spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.6"
   spec.add_development_dependency "pry-byebug", "~> 3.4"

--- a/lib/graphql/remote_loader/query_merger.rb
+++ b/lib/graphql/remote_loader/query_merger.rb
@@ -45,7 +45,7 @@ module GraphQL
             if matching_fragment_definition
               merge_query_recursive(a_definition, matching_fragment_definition)
             else
-              b_query.definitions << a_definition
+              b_query.instance_variable_set(:@definitions, [b_query.definitions, a_definition].flatten)
             end
           end
         end
@@ -79,7 +79,7 @@ module GraphQL
               matching_field.instance_variable_set(:@prime, new_prime)
               merge_query_recursive(a_query_selection, matching_field) unless exempt_node_types.any? { |type| matching_field.is_a?(type) }
             else
-              b_query.selections << a_query_selection
+              b_query.instance_variable_set(:@selections, [b_query.selections, a_query_selection].flatten)
             end
           end
         end
@@ -112,11 +112,11 @@ module GraphQL
             unless exempt_node_types.any? { |type| selection.is_a? type }
               prime_factor = selection.instance_variable_get(:@prime)
 
-              selection.alias = if selection.alias
+              selection.instance_variable_set(:@alias, if selection.alias
                 "p#{prime_factor}#{selection.alias}"
               else
                 "p#{prime_factor}#{selection.name}"
-              end
+              end)
             end
 
             # Some nodes don't have selections (e.g. fragment spreads)

--- a/lib/graphql/remote_loader/query_merger.rb
+++ b/lib/graphql/remote_loader/query_merger.rb
@@ -45,6 +45,8 @@ module GraphQL
             if matching_fragment_definition
               merge_query_recursive(a_definition, matching_fragment_definition)
             else
+              # graphql-ruby Nodes aren't meant to be mutated, but I'd rather slightly abuse graphql-ruby vs
+              # maintain my own Ruby data and parsing library implementing the GraphQL spec.
               b_query.instance_variable_set(:@definitions, [b_query.definitions, a_definition].flatten)
             end
           end

--- a/lib/graphql/remote_loader/version.rb
+++ b/lib/graphql/remote_loader/version.rb
@@ -1,5 +1,5 @@
 module GraphQL
   module RemoteLoader
-    VERSION = "1.0.4"
+    VERSION = "1.0.5"
   end
 end


### PR DESCRIPTION
Closes #27

This gem stopped working for `graphql-ruby >= 1.9` because nodes in the gem were made immutable. `graphql_remote-loader` slightly abuses the `graphql-ruby` gem and uses the parsed AST as a query builder. We do this since Robert's GraphQL implementation is very complete, and I don't really want to build my own query parser and keep up with the moving spec. 

I'm not aware of a great "official" way to do this with the GraphQL gem at the moment, so I've just worked around the immutability with a bit of metaprogramming (sorry Robert!). Rebuilding the entire document every time we need to mutate it isn't computationally feasible in this case.