### PR TITLE
Frozen string literals

### DIFF
--- a/graphql-remote_loader.gemspec
+++ b/graphql-remote_loader.gemspec
@@ -1,4 +1,6 @@
 # coding: utf-8
+# frozen_string_literal: true
+
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'graphql/remote_loader/version'

--- a/lib/graphql/remote_loader.rb
+++ b/lib/graphql/remote_loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "graphql"
 require "graphql/batch"
 

--- a/lib/graphql/remote_loader/loader.rb
+++ b/lib/graphql/remote_loader/loader.rb
@@ -21,9 +21,7 @@ module GraphQL
 
         store_context(context)
 
-        interpolate_variables!(query, variables)
-
-        self.for.load([query, prime, @context])
+        self.for.load([interpolate_variables(query, variables), prime, @context])
       end
 
       # Loads the value, then if the query was successful, fulfills promise with
@@ -99,6 +97,10 @@ module GraphQL
       # E.g.
       #   interpolate_variables("foo(bar: $my_var)", { my_var: "buzz" })
       #   => "foo(bar: \"buzz\")"
+      def self.interpolate_variables(query, variables = {})
+        query.dup.tap { |mutable_query| interpolate_variables!(mutable_query, variables) }
+      end
+
       def self.interpolate_variables!(query, variables = {})
         variables.each do |variable, value|
           case value

--- a/lib/graphql/remote_loader/loader.rb
+++ b/lib/graphql/remote_loader/loader.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "prime"
 require "json"
 require_relative "query_merger"

--- a/lib/graphql/remote_loader/query_merger.rb
+++ b/lib/graphql/remote_loader/query_merger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GraphQL
   module RemoteLoader
     # Given a list of queries and their prime UIDs, generate the merged and labeled

--- a/lib/graphql/remote_loader/version.rb
+++ b/lib/graphql/remote_loader/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module GraphQL
   module RemoteLoader
     VERSION = "1.0.5"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/setup'
 Bundler.setup
 

--- a/spec/unit/lib/graphql/remote_loader/loader_spec.rb
+++ b/spec/unit/lib/graphql/remote_loader/loader_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 class TestLoader < GraphQL::RemoteLoader::Loader

--- a/spec/unit/lib/graphql/remote_loader/query_merger_spec.rb
+++ b/spec/unit/lib/graphql/remote_loader/query_merger_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 describe GraphQL::RemoteLoader::QueryMerger do


### PR DESCRIPTION
`Loader.load` fails if the query string is frozen, because `interpolate_variables!` attempts to mutate it with `gsub!`.

This PR enables frozen string literals across the codebase (which causes this error to occur in unit specs) and fixes the `load` method to duplicate the string before mutation.