### PR TITLE
Move to bitmap caller IDs instead of prime factors

### DIFF
--- a/spec/unit/lib/graphql/remote_loader/loader_spec.rb
+++ b/spec/unit/lib/graphql/remote_loader/loader_spec.rb
@@ -46,11 +46,11 @@ describe GraphQL::RemoteLoader::Loader do
   context "hitting the loader with multiple fields" do
     it "returns the correct results and only makes one query" do
       TestLoader.any_instance.should_receive(:query).once
-        .with("query { p3bar: bar p2foo: foo }", anything)
+        .with("query { p4bar: bar p2foo: foo }", anything)
         .and_return({
           "data" => {
             "p2foo" => "foo_result",
-            "p3bar" => "bar_result"
+            "p4bar" => "bar_result"
           }
         })
 
@@ -195,12 +195,12 @@ describe GraphQL::RemoteLoader::Loader do
   context "hitting the loader with overlapping fields with different sub-selections" do
     it "returns the correct results and only makes one query" do
       TestLoader.any_instance.should_receive(:query).once
-        .with("query { p6foo: foo { p3buzz: buzz p2bar: bar } }", anything)
+        .with("query { p6foo: foo { p4buzz: buzz p2bar: bar } }", anything)
         .and_return({
           "data" => {
             "p6foo" => {
               "p2bar" => "bar_result",
-              "p3buzz" => "buzz_result"
+              "p4buzz" => "buzz_result"
             }
           }
         })
@@ -223,14 +223,14 @@ describe GraphQL::RemoteLoader::Loader do
   context "hitting the loader with fields with differing argument values" do
     it "returns the correct results and only makes one query" do
       TestLoader.any_instance.should_receive(:query).once
-        .with("query { p3foo: foo(bar: 2) { p3buzz: buzz } p2foo: foo(bar: 1) { p2buzz: buzz } }", anything)
+        .with("query { p4foo: foo(bar: 2) { p4buzz: buzz } p2foo: foo(bar: 1) { p2buzz: buzz } }", anything)
         .and_return({
           "data" => {
             "p2foo" => {
               "p2buzz" => "buzz_first_result"
             },
-            "p3foo" => {
-              "p3buzz" => "buzz_second_result"
+            "p4foo" => {
+              "p4buzz" => "buzz_second_result"
             }
           }
         })
@@ -265,11 +265,11 @@ describe GraphQL::RemoteLoader::Loader do
   context "hitting the loader with fields with overlapping aliases" do
     it "returns the correct results and only makes one query" do
       TestLoader.any_instance.should_receive(:query).once
-        .with("query { p3foo: bazz p2foo: bar }", anything)
+        .with("query { p4foo: bazz p2foo: bar }", anything)
         .and_return({
           "data" => {
             "p2foo" => "bar_result",
-            "p3foo" => "bazz_result"
+            "p4foo" => "bazz_result"
           }
         })
 
@@ -283,11 +283,11 @@ describe GraphQL::RemoteLoader::Loader do
 
     it "fulfills promises with only the data they asked for" do
       TestLoader.any_instance.should_receive(:query).once
-        .with("query { p3buzz: bazz p2foo: bar }", anything)
+        .with("query { p4buzz: bazz p2foo: bar }", anything)
         .and_return({
           "data" => {
             "p2foo" => "bar_result",
-            "p3buzz" => "bazz_result"
+            "p4buzz" => "bazz_result"
           }
         })
 

--- a/spec/unit/lib/graphql/remote_loader/query_merger_spec.rb
+++ b/spec/unit/lib/graphql/remote_loader/query_merger_spec.rb
@@ -7,7 +7,7 @@ describe GraphQL::RemoteLoader::QueryMerger do
   describe ".merge" do
     context "when passed one query" do
       context "when there is one field" do
-        let(:result) { subject.merge([["foo", 2]]) }
+        let(:result) { subject.merge([["foo", 1]]) }
 
         it "returns the expected query" do
           expected_result = <<~GRAPHQL
@@ -20,7 +20,7 @@ describe GraphQL::RemoteLoader::QueryMerger do
       end
 
       context "when there is multiple fields" do
-        let(:result) { subject.merge([["foo bar { buzz }", 2]]) }
+        let(:result) { subject.merge([["foo bar { buzz }", 1]]) }
 
         it "returns the expected query" do
           expected_result = <<~GRAPHQL
@@ -36,7 +36,7 @@ describe GraphQL::RemoteLoader::QueryMerger do
       end
 
       context "when there are field aliases" do
-        let(:result) { subject.merge([["foo: bar", 2]]) }
+        let(:result) { subject.merge([["foo: bar", 1]]) }
 
         it "returns the expected query" do
           expected_result = <<~GRAPHQL
@@ -49,7 +49,7 @@ describe GraphQL::RemoteLoader::QueryMerger do
       end
 
       context "when there are directives" do
-        let(:result) { subject.merge([["foo @bar", 2]]) }
+        let(:result) { subject.merge([["foo @bar", 1]]) }
 
         it "returns the expected query" do
           expected_result = <<~GRAPHQL
@@ -62,7 +62,7 @@ describe GraphQL::RemoteLoader::QueryMerger do
       end
 
       context "when there are defined fragments" do
-        let(:result) { subject.merge([["query { foo { ... MyFragment } } fragment MyFragment on Foo { bar }", 2]]) }
+        let(:result) { subject.merge([["query { foo { ... MyFragment } } fragment MyFragment on Foo { bar }", 1]]) }
 
         # In order to resolve fields on fragments correctly, all
         # fields on fragments must have prefixes
@@ -83,7 +83,7 @@ describe GraphQL::RemoteLoader::QueryMerger do
       end
 
       context "when there are directives with arguments" do
-        let(:result) { subject.merge([["foo @bar(buzz: 1)", 2]]) }
+        let(:result) { subject.merge([["foo @bar(buzz: 1)", 1]]) }
 
         it "returns the expected query" do
           expected_result = <<~GRAPHQL
@@ -96,7 +96,7 @@ describe GraphQL::RemoteLoader::QueryMerger do
       end
 
       context "when there are arguments" do
-        let(:result) { subject.merge([["foo(bar: 5){ buzz }", 2]]) }
+        let(:result) { subject.merge([["foo(bar: 5){ buzz }", 1]]) }
 
         it "returns the expected query" do
           expected_result = <<~GRAPHQL
@@ -111,7 +111,7 @@ describe GraphQL::RemoteLoader::QueryMerger do
       end
 
       context "when there are inline fragments" do
-        let(:result) { subject.merge([["foo { ... on Bar { buzz } }", 2]]) }
+        let(:result) { subject.merge([["foo { ... on Bar { buzz } }", 1]]) }
 
         it "returns the expected query" do
           expected_result = <<~GRAPHQL
@@ -130,13 +130,13 @@ describe GraphQL::RemoteLoader::QueryMerger do
 
     context "when passed multiple queries" do
       context "when there is no overlap" do
-        let(:result) { subject.merge([["foo bar", 2], ["buzz bazz", 3]]) }
+        let(:result) { subject.merge([["foo bar", 1], ["buzz bazz", 2]]) }
 
         it "returns the expected query" do
           expected_result = <<~GRAPHQL
             query {
-              p3buzz: buzz
-              p3bazz: bazz
+              p4buzz: buzz
+              p4bazz: bazz
               p2foo: foo
               p2bar: bar
             }
@@ -146,13 +146,13 @@ describe GraphQL::RemoteLoader::QueryMerger do
       end
 
       context "when there is no overlap because of arguments" do
-        let(:result) { subject.merge([["foo(buzz: 1) { bar }", 2], ["foo(buzz: 2) {  bar }", 3]]) }
+        let(:result) { subject.merge([["foo(buzz: 1) { bar }", 1], ["foo(buzz: 2) {  bar }", 2]]) }
 
         it "returns the expected query" do
           expected_result = <<~GRAPHQL
             query {
-              p3foo: foo(buzz: 2) {
-                p3bar: bar
+              p4foo: foo(buzz: 2) {
+                p4bar: bar
               }
               p2foo: foo(buzz: 1) {
                 p2bar: bar
@@ -164,13 +164,13 @@ describe GraphQL::RemoteLoader::QueryMerger do
       end
 
       context "when there is overlap" do
-        let(:result) { subject.merge([["foo { bar }", 2], ["foo { buzz }", 3]]) }
+        let(:result) { subject.merge([["foo { bar }", 1], ["foo { buzz }", 2]]) }
 
         it "returns the expected query" do
           expected_result = <<~GRAPHQL
             query {
               p6foo: foo {
-                p3buzz: buzz
+                p4buzz: buzz
                 p2bar: bar
               }
             }
@@ -181,12 +181,12 @@ describe GraphQL::RemoteLoader::QueryMerger do
 
       context "when there are aliases" do
         context "when there is no overlap" do
-          let(:result) { subject.merge([["foo: bar", 2], ["buzz: bazz", 3]]) }
+          let(:result) { subject.merge([["foo: bar", 1], ["buzz: bazz", 2]]) }
 
           it "returns the expected query" do
             expected_result = <<~GRAPHQL
               query {
-                p3buzz: bazz
+                p4buzz: bazz
                 p2foo: bar
               }
             GRAPHQL
@@ -196,12 +196,12 @@ describe GraphQL::RemoteLoader::QueryMerger do
 
         # Notice we do not merge if aliases are differing.
         context "when there is field name overlap but differing aliases" do
-          let(:result) { subject.merge([["foo: bar", 2], ["buzz: bar", 3]]) }
+          let(:result) { subject.merge([["foo: bar", 1], ["buzz: bar", 2]]) }
 
           it "returns the expected query" do
             expected_result = <<~GRAPHQL
               query {
-                p3buzz: bar
+                p4buzz: bar
                 p2foo: bar
               }
             GRAPHQL
@@ -210,7 +210,7 @@ describe GraphQL::RemoteLoader::QueryMerger do
         end
 
         context "when there is field name overlap and same aliases" do
-          let(:result) { subject.merge([["foo: bar", 2], ["foo: bar", 3]]) }
+          let(:result) { subject.merge([["foo: bar", 1], ["foo: bar", 2]]) }
 
           it "returns the expected query" do
             expected_result = <<~GRAPHQL
@@ -224,12 +224,12 @@ describe GraphQL::RemoteLoader::QueryMerger do
       end
 
       context "when there are directives" do
-        let(:result) { subject.merge([["foo @bar", 2], ["buzz @bazz", 3]]) }
+        let(:result) { subject.merge([["foo @bar", 1], ["buzz @bazz", 2]]) }
 
         it "returns the expected query" do
           expected_result = <<~GRAPHQL
             query {
-              p3buzz: buzz @bazz
+              p4buzz: buzz @bazz
               p2foo: foo @bar
             }
           GRAPHQL
@@ -238,12 +238,12 @@ describe GraphQL::RemoteLoader::QueryMerger do
       end
 
       context "when there are directives with arguments" do
-        let(:result) { subject.merge([["foo @bar(a: 1)", 2], ["buzz @bazz(a: 1)", 3]]) }
+        let(:result) { subject.merge([["foo @bar(a: 1)", 1], ["buzz @bazz(a: 1)", 2]]) }
 
         it "returns the expected query" do
           expected_result = <<~GRAPHQL
             query {
-              p3buzz: buzz @bazz(a: 1)
+              p4buzz: buzz @bazz(a: 1)
               p2foo: foo @bar(a: 1)
             }
           GRAPHQL
@@ -253,8 +253,8 @@ describe GraphQL::RemoteLoader::QueryMerger do
 
       context "when there are defined fragments that are unique" do
         let(:result) { subject.merge([
-            ["query { foo { ... MyFragment } } fragment MyFragment on Foo { bar }", 2],
-            ["query { foo { ... OtherFragment } } fragment OtherFragment on Buzz { bazz }", 3]
+            ["query { foo { ... MyFragment } } fragment MyFragment on Foo { bar }", 1],
+            ["query { foo { ... OtherFragment } } fragment OtherFragment on Buzz { bazz }", 2]
           ])}
 
         # In order to resolve fields on fragments correctly, all
@@ -269,7 +269,7 @@ describe GraphQL::RemoteLoader::QueryMerger do
             }
 
             fragment OtherFragment on Buzz {
-              p3bazz: bazz
+              p4bazz: bazz
             }
 
             fragment MyFragment on Foo {
@@ -282,8 +282,8 @@ describe GraphQL::RemoteLoader::QueryMerger do
 
       context "when there are defined fragments that are NOT unique" do
         let(:result) { subject.merge([
-            ["query { foo { ... MyFragment } } fragment MyFragment on Foo { bar }", 2],
-            ["query { foo { ... MyFragment } } fragment MyFragment on Foo { bar bazz }", 3]
+            ["query { foo { ... MyFragment } } fragment MyFragment on Foo { bar }", 1],
+            ["query { foo { ... MyFragment } } fragment MyFragment on Foo { bar bazz }", 2]
           ])}
 
         # In order to resolve fields on fragments correctly, all
@@ -298,7 +298,7 @@ describe GraphQL::RemoteLoader::QueryMerger do
 
             fragment MyFragment on Foo {
               p6bar: bar
-              p3bazz: bazz
+              p4bazz: bazz
             }
           GRAPHQL
           expect(result).to eq(expected_result.strip)
@@ -306,14 +306,14 @@ describe GraphQL::RemoteLoader::QueryMerger do
       end
 
       context "when there is argument overlap" do
-        let(:result) { subject.merge([["foo(buzz: 1) { bar }", 2], ["foo(buzz: 1) {  bar bazz }", 3]]) }
+        let(:result) { subject.merge([["foo(buzz: 1) { bar }", 1], ["foo(buzz: 1) {  bar bazz }", 2]]) }
 
         it "returns the expected query" do
           expected_result = <<~GRAPHQL
             query {
               p6foo: foo(buzz: 1) {
                 p6bar: bar
-                p3bazz: bazz
+                p4bazz: bazz
               }
             }
           GRAPHQL
@@ -322,7 +322,7 @@ describe GraphQL::RemoteLoader::QueryMerger do
       end
 
       context "when there are merging inline fragments" do
-        let(:result) { subject.merge[["foo { ... on Bar { buzz } }", 2], ["foo { ... on Bar { bazz } }", 3]] }
+        let(:result) { subject.merge[["foo { ... on Bar { buzz } }", 1], ["foo { ... on Bar { bazz } }", 2]] }
 
         # It may seem strange that the inline fragments don't get merged here since their types are equal.
         # And I agree. That's certainly odd.
@@ -333,7 +333,7 @@ describe GraphQL::RemoteLoader::QueryMerger do
             query {
               p6foo {
                 ... on Bar {
-                  p3bazz
+                  p4bazz
                 }
                 ... on Bar {
                   p2buzz


### PR DESCRIPTION
Closes #26 

Moving to bitmap caller IDs instead of prime factors for reasons listed in #26. Most of this PR is renaming variables.