### PR TITLE
add support for array variables

### DIFF
--- a/lib/graphql/remote_loader/loader.rb
+++ b/lib/graphql/remote_loader/loader.rb
@@ -101,7 +101,7 @@ module GraphQL
       def self.interpolate_variables!(query, variables = {})
         variables.each do |variable, value|
           case value
-          when Integer, Float, TrueClass, FalseClass
+          when Integer, Float, TrueClass, FalseClass, Array
             # These types are safe to directly interpolate into the query, and GraphQL does not expect these types to be quoted.
             query.gsub!("$#{variable.to_s}", value.to_s)
           else

--- a/lib/graphql/remote_loader/loader.rb
+++ b/lib/graphql/remote_loader/loader.rb
@@ -99,22 +99,32 @@ module GraphQL
       end
 
       def self.interpolate_variables!(query, variables = {})
-        variables.each do |variable, value|
-          case value
-          when Integer, Float, TrueClass, FalseClass, Array
-            # These types are safe to directly interpolate into the query, and GraphQL does not expect these types to be quoted.
-            query.gsub!("$#{variable.to_s}", value.to_s)
-          else
-            # A string is either a GraphQL String or ID type.
-            # This means we need to
-            # a) Surround the value in quotes
-            # b) escape special characters in the string
-            #
-            # This else also catches unknown objects, which could break the query if we directly interpolate.
-            # These objects get converted to strings, then escaped.
+        variables.each { |variable, value| query.gsub!("$#{variable.to_s}", stringify_variable(value)) }
+      end
 
-            query.gsub!("$#{variable.to_s}", value.to_s.inspect)
-          end
+      def self.stringify_variable(value)
+        case value
+        when Integer, Float, TrueClass, FalseClass
+          # These types are safe to directly interpolate into the query, and GraphQL does not expect these types to be quoted.
+          value.to_s
+        when Array
+          # Arrays can contain elements with various types, so we need to check them one by one
+          stringified_elements = value.map { |element| stringify_variable(element) }
+          "[#{stringified_elements.join(', ')}]"
+        when Hash
+          # Hashes can contain values with various types, so we need to check them one by one
+          stringified_key_value_pairs = value.map { |key, value| "#{key}: #{stringify_variable(value)}" }
+          "{#{stringified_key_value_pairs.join(', ')}}"
+        else
+          # A string is either a GraphQL String or ID type.
+          # This means we need to
+          # a) Surround the value in quotes
+          # b) escape special characters in the string
+          #
+          # This else also catches unknown objects, which could break the query if we directly interpolate.
+          # These objects get converted to strings, then escaped.
+
+          value.to_s.inspect
         end
       end
 

--- a/spec/unit/lib/graphql/remote_loader/loader_spec.rb
+++ b/spec/unit/lib/graphql/remote_loader/loader_spec.rb
@@ -137,10 +137,10 @@ describe GraphQL::RemoteLoader::Loader do
       TestLoader.any_instance.should_receive(:query).once
         .with('query { p2foo: foo(bar: {array: ["fir\"st", true, 5], text: "value", number: 6}) }', anything)
         .and_return({
-                      "data" => {
-                        "p2foo" => "foo_result"
-                      }
-                    })
+          "data" => {
+            "p2foo" => "foo_result"
+          }
+        })
 
       results = GraphQL::Batch.batch do
         TestLoader.load("foo(bar: $my_variable)",

--- a/spec/unit/lib/graphql/remote_loader/loader_spec.rb
+++ b/spec/unit/lib/graphql/remote_loader/loader_spec.rb
@@ -116,6 +116,22 @@ describe GraphQL::RemoteLoader::Loader do
       expect(results["data"]["foo"]).to eq("foo_result")
     end
 
+    it "interpolates array variables correctly" do
+      TestLoader.any_instance.should_receive(:query).once
+        .with('query { p2foo: foo(bar: ["first", "last"]) }', anything)
+        .and_return({
+          "data" => {
+            "p2foo" => "foo_result"
+          }
+        })
+
+      results = GraphQL::Batch.batch do
+        TestLoader.load("foo(bar: $my_variable)", variables: { my_variable: ["first", "last"] })
+      end
+
+      expect(results["data"]["foo"]).to eq("foo_result")
+    end
+
     it "interpolates string variables correctly" do
       TestLoader.any_instance.should_receive(:query).once
         .with("query { p2foo: foo(bar: \"testing string\") }", anything)


### PR DESCRIPTION
Added support for array variables. Without this change `inspect` escaped the double quotes around elements and it turned out to be something like `[\"first element\", \"second element\"]`.